### PR TITLE
Feature #12259

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
       </dependency>
       <dependency>
         <groupId>org.wildfly.arquillian</groupId>
-        <artifactId>wildfly-arquillian-container-managed</artifactId>
+        <artifactId>wildfly-arquillian-container-remote</artifactId>
         <version>${arquillian.wildfly.version}</version>
         <scope>test</scope>
         <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <groupId>org.silverpeas</groupId>
   <artifactId>silverpeas-test-dependencies-bom</artifactId>
-  <version>1.5-SNAPSHOT</version>
+  <version>1.5-improve-it</version>
   <packaging>pom</packaging>
   <name>Silverpeas Test Dependencies BOM</name>
   <description>A BOM with all the dependencies required to build and run the unit and the integration tests of Silverpeas</description>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <groupId>org.silverpeas</groupId>
   <artifactId>silverpeas-test-dependencies-bom</artifactId>
-  <version>1.5-improve-it</version>
+  <version>1.5-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Silverpeas Test Dependencies BOM</name>
   <description>A BOM with all the dependencies required to build and run the unit and the integration tests of Silverpeas</description>


### PR DESCRIPTION
Refactor the way the integration tests are running: instead of starting a Wildfly instance for each test class, it is started before the execution of the whole integration tests of the project. So, Wildfly is set as a remote container for Arquillian.
This requires to set up differently Wildfly. Currently, Wildfly 23.0.0 has been prepared for that and a Docker image dedicated to such builds has been pushed into the hub: silverpeas/silverbuild:6.3-it.