### PR TITLE
Bug #12648

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <groupId>org.silverpeas</groupId>
   <artifactId>silverpeas-test-dependencies-bom</artifactId>
-  <version>1.4</version>
+  <version>1.4.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Silverpeas Test Dependencies BOM</name>
   <description>A BOM with all the dependencies required to build and run the unit and the integration tests of Silverpeas</description>
@@ -41,7 +41,7 @@
     <developerConnection>scm:git:git@github.com:Silverpeas/silverpeas-test-dependencies-bom.git
     </developerConnection>
     <url>https://gitub.com/Silverpeas/silverpeas-test-dependencies-bom.git</url>
-    <tag>1.4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>


### PR DESCRIPTION
Updating old library itext to the most recent one.

Updating Log4j to 2.15 version.

Linked to PRs:
* https://github.com/Silverpeas/silverpeas-dependencies-bom/pull/25
* https://github.com/Silverpeas/Silverpeas-Project/pull/7
* https://github.com/Silverpeas/Silverpeas-Core/pull/1178
* https://github.com/Silverpeas/Silverpeas-Components/pull/763
* https://github.com/Silverpeas/Silverpeas-Looks/pull/56
* https://github.com/Silverpeas/Silverpeas-Assembly/pull/20
* https://github.com/Silverpeas/silverpeasmobile/pull/26