### PR TITLE
Feature #13059

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,31 @@
       	<scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.glassfish.jersey.core</groupId>
+        <artifactId>jersey-common</artifactId>
+        <version>2.26</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
         <groupId>org.jboss.arquillian.junit</groupId>
         <artifactId>arquillian-junit-core</artifactId>
         <version>${arquillian.version}</version>


### PR DESCRIPTION
With a changes in the dependencies driven by an update of JackRabbit (to
2.20.5), some transitive dependencies required by tests weren't more present.
Take into account of such a change.

Don't forget to merge also PR https://github.com/Silverpeas/silverpeas-dependencies-bom/pull/40