### PR TITLE
Feature #12866

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,7 +310,16 @@
         <version>1.9.4</version>
         <scope>test</scope>
       </dependency>
+
+      <!-- for testing with MongDB -->
+      <dependency>
+        <groupId>de.flapdoodle.embed</groupId>
+        <artifactId>de.flapdoodle.embed.mongo</artifactId>
+        <version>4.4.1</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
+
   </dependencyManagement>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
       <dependency>
         <groupId>org.junit.platform</groupId>
         <artifactId>junit-platform-runner</artifactId>
-        <version>1.8.2</version>
+        <version>1.9.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -101,6 +101,18 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-junit-jupiter</artifactId>
         <version>${mokito.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy</artifactId>
+        <version>${byte-buddy.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy-agent</artifactId>
+        <version>${byte-buddy.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -140,13 +152,13 @@
       <dependency>
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
-        <version>4.1.1</version>
+        <version>4.2.0</version>
       </dependency>
       <!-- TODO to be removed later in profit of DbSetup -->
       <dependency>
         <groupId>org.dbunit</groupId>
         <artifactId>dbunit</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-collections</groupId>
@@ -279,7 +291,7 @@
       <dependency>
         <groupId>com.icegreen</groupId>
         <artifactId>greenmail</artifactId>
-        <version>1.6.5</version>
+        <version>1.6.13</version>
         <scope>test</scope>
       </dependency>
 
@@ -306,11 +318,12 @@
     <next.release>1.6</next.release>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <junit.version>5.8.2</junit.version>
-    <mokito.version>4.2.0</mokito.version>
+    <junit.version>5.9.2</junit.version>
+    <mokito.version>4.5.1</mokito.version>
+    <byte-buddy.version>1.12.9</byte-buddy.version>
     <weld-junit.version>2.0.2.Final</weld-junit.version>
     <dbsetup.version>2.1.0</dbsetup.version>
-    <resteasy.version>3.15.3.Final</resteasy.version>
+    <resteasy.version>4.7.7.Final</resteasy.version>
     <arquillian.version>1.6.0.Final</arquillian.version>
     <arquillian.wildfly.version>3.0.1.Final</arquillian.wildfly.version>
   </properties>


### PR DESCRIPTION
In the replacement of Jackrabbit by Oak, the access to the JCR repository is now done by a lib instead of a JCA. So dependencies requires to be managed differently.

The following PRs require to be merged along with this one:
- https://github.com/Silverpeas/silverpeas-dependencies-bom/pull/47
- https://github.com/Silverpeas/Silverpeas-Project/pull/8

The following project requires to be pushed onto the Silverpeas org:
- https://github.com/SilverTeamWork/Silverpeas-JCR

The following PRs require to be integrated after this one:
- https://github.com/Silverpeas/Silverpeas-Core/pull/1255
- https://github.com/Silverpeas/Silverpeas-Components/pull/809
- https://github.com/Silverpeas/Silverpeas-Assembly/pull/24